### PR TITLE
24/add types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ test/tmp
 !.yarn/sdks
 !.yarn/versions
 yarn-error.log
+
+# editors
+.idea/

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/index.ts",
+  "types": "dist/src/index.d.ts",
   "repository": "git@github.com:graasp/graasp-apps-query-client.git",
   "author": "Graasp Association",
   "workspaces": [

--- a/src/api/appSetting.ts
+++ b/src/api/appSetting.ts
@@ -23,7 +23,7 @@ export const getAppSettings = async (args: { token: string; itemId: string; apiH
 export const postAppSetting = (args: {
   token: string;
   itemId: string;
-  body: any;
+  body: unknown;
   apiHost: string;
 }) => {
   const { token, itemId, apiHost, body } = args;
@@ -41,7 +41,7 @@ export const patchAppSetting = (args: {
   itemId: string;
   id: string;
   apiHost: string;
-  data: any;
+  data: unknown;
 }) => {
   const { token, itemId, id, apiHost, data } = args;
   return axios

--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -38,7 +38,7 @@ export const getAppData = async (args: { token: string; itemId: string; apiHost:
 export const postAppData = (args: {
   token: string;
   itemId: string;
-  body: any;
+  body: unknown;
   apiHost: string;
 }) => {
   const { token, itemId, apiHost, body } = args;
@@ -56,7 +56,7 @@ export const patchAppData = (args: {
   itemId: string;
   id: string;
   apiHost: string;
-  data: any;
+  data: unknown;
 }) => {
   const { token, itemId, id, apiHost, data } = args;
   return axios
@@ -102,7 +102,7 @@ export const getAppActions = async (args: { token: string; itemId: string; apiHo
 export const postAppAction = (args: {
   token: string;
   itemId: string;
-  body: any;
+  body: unknown;
   apiHost: string;
 }) => {
   const { token, itemId, apiHost, body } = args;

--- a/src/hooks/appSetting.test.ts
+++ b/src/hooks/appSetting.test.ts
@@ -123,7 +123,10 @@ describe('App Settings Hooks', () => {
     it('Receive file content', async () => {
       queryClient.setQueryData(LOCAL_CONTEXT_KEY, Map(buildMockLocalContext()));
 
-      const endpoints = [{ route, response: responseFile }, { route: routeFile, response }];
+      const endpoints = [
+        { route, response: responseFile },
+        { route: routeFile, response },
+      ];
       const { data } = await mockHook({ endpoints, hook, wrapper });
 
       expect(data).toBeTruthy();

--- a/src/hooks/apps.test.ts
+++ b/src/hooks/apps.test.ts
@@ -206,7 +206,10 @@ describe('App Hooks', () => {
     it('Receive file content', async () => {
       queryClient.setQueryData(LOCAL_CONTEXT_KEY, Map(buildMockLocalContext()));
 
-      const endpoints = [{ route, response: responseFile }, { route: routeFile, response }];
+      const endpoints = [
+        { route, response: responseFile },
+        { route: routeFile, response },
+      ];
       const { data } = await mockHook({ endpoints, hook, wrapper });
 
       expect(data).toBeTruthy();

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,12 +49,12 @@ export type AppData = {
 export type AppAction = {
   id: UUID;
   type: string;
-  data: any;
+  data: unknown;
 };
 
 export type AppSetting = {
   id: UUID;
-  data: any;
+  data: unknown;
   name: string;
 };
 


### PR DESCRIPTION
This PR adds the "types" property to `package.json` so that TS users can consume the types.

It also changes some types from `any` to `unknown` where possible. Places such as when using `post`, `patch` etc ... since the `data` property is already defined as `unknown` which removes the eslint warning about using any type.

closes #24 