### PR TITLE
fix: make `appAction` plural

### DIFF
--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -5,7 +5,7 @@ import {
   buildGetContextRoute,
   buildPatchAppDataRoute,
   buildPostAppDataRoute,
-  buildGetAppActionRoute,
+  buildGetAppActionsRoute,
   buildPostAppActionRoute,
 } from './routes';
 import configureAxios from './axios';
@@ -91,7 +91,7 @@ export const deleteAppData = (args: {
 export const getAppActions = async (args: { token: string; itemId: string; apiHost: string }) => {
   const { token, itemId, apiHost } = args;
   return axios
-    .get(`${apiHost}/${buildGetAppActionRoute(itemId)}`, {
+    .get(`${apiHost}/${buildGetAppActionsRoute(itemId)}`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -20,7 +20,7 @@ export const buildPatchAppDataRoute = (payload: { itemId: string; id: string }) 
 export const buildDeleteAppDataRoute = (payload: { itemId: string; id: string }) =>
   `${APP_ITEMS_ROUTE}/${payload.itemId}/${APP_DATA_ENDPOINT}/${payload.id}`;
 
-export const buildGetAppActionRoute = (itemId: string) =>
+export const buildGetAppActionsRoute = (itemId: string) =>
   `${APP_ITEMS_ROUTE}/${itemId}/${APP_ACTIONS_ENDPOINT}`;
 
 export const buildPostAppActionRoute = (payload: { itemId: string }) =>
@@ -60,7 +60,7 @@ export const API_ROUTES = {
   buildGetContextRoute,
   buildPostAppDataRoute,
   buildPatchAppDataRoute,
-  buildGetAppActionRoute,
+  buildGetAppActionsRoute,
   buildPostAppActionRoute,
   buildGetAppSettingsRoute,
   buildPatchAppSettingRoute,

--- a/src/config/keys.ts
+++ b/src/config/keys.ts
@@ -1,7 +1,7 @@
 import { UUID } from '../types';
 
 export const buildAppDataKey = (id?: UUID) => [id, 'app-data'];
-export const buildAppActionKey = (id?: UUID) => [id, 'app-action'];
+export const buildAppActionsKey = (id?: UUID) => [id, 'app-action'];
 export const buildAppSettingsKey = (id?: UUID) => [id, 'app-settings'];
 export const buildAppContextKey = (id?: UUID) => [id, 'context'];
 export const AUTH_TOKEN_KEY = 'AUTH_TOKEN_KEY';
@@ -39,5 +39,5 @@ export const MUTATION_KEYS = {
 export const HOOK_KEYS = {
   buildAppDataKey,
   buildAppContextKey,
-  buildAppActionKey,
+  buildAppActionsKey,
 };

--- a/src/hooks/apps.ts
+++ b/src/hooks/apps.ts
@@ -3,7 +3,7 @@ import { QueryClient, useQuery } from 'react-query';
 import * as Api from '../api';
 import { MissingFileIdError, MissingItemIdError, MissingTokenError } from '../config/errors';
 import {
-  buildAppActionKey,
+  buildAppActionsKey,
   buildAppContextKey,
   buildAppDataKey,
   buildFileContentKey,
@@ -44,7 +44,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
 
     useAppActions: (payload: { token?: string; itemId?: string }) =>
       useQuery({
-        queryKey: buildAppActionKey(payload.itemId),
+        queryKey: buildAppActionsKey(payload.itemId),
         queryFn: () => {
           const apiHost = getApiHost(queryClient);
           const { token, itemId } = payload;

--- a/src/mockServer/mockServer.js
+++ b/src/mockServer/mockServer.js
@@ -1,7 +1,7 @@
 import { createServer, Model, Factory, RestSerializer, Response } from 'miragejs';
 import { v4 } from 'uuid';
 import { API_ROUTES } from '../api/routes';
-import { buildMockLocalContext } from './fixtures';
+import { buildMockLocalContext, MOCK_SERVER_MEMBER } from './fixtures';
 
 const {
   buildGetAppDataRoute,
@@ -12,7 +12,7 @@ const {
   buildUploadFilesRoute,
   buildDeleteAppSettingRoute,
   buildDownloadFileRoute,
-  buildGetAppActionRoute,
+  buildGetAppActionsRoute,
   buildGetAppSettingsRoute,
   buildPatchAppSettingRoute,
   buildPostAppActionRoute,
@@ -27,14 +27,14 @@ const ApplicationSerializer = RestSerializer.extend({
 const setupApi = ({
   database = {
     appData: [],
-    appAction: [],
+    appActions: [],
     appSettings: [],
     members: [MOCK_SERVER_MEMBER],
   },
   appContext = buildMockLocalContext(),
   errors = {},
 } = {}) => {
-  const { appData, appAction, appSettings, members } = database;
+  const { appData, appActions, appSettings, members } = database;
   const { itemId: currentItemId, memberId: currentMemberId, apiHost } = appContext;
   // mocked errors
   const { deleteAppDataShouldThrow } = errors;
@@ -106,7 +106,7 @@ const setupApi = ({
       appData?.forEach((d) => {
         server.create('appDataResource', d);
       });
-      appAction?.forEach((d) => {
+      appActions?.forEach((d) => {
         server.create('appActionResource', d);
       });
       appSettings?.forEach((d) => {
@@ -153,7 +153,7 @@ const setupApi = ({
       );
 
       // app actions
-      this.get(`/${buildGetAppActionRoute(currentItemId)}`, (schema) => {
+      this.get(`/${buildGetAppActionsRoute(currentItemId)}`, (schema) => {
         return schema.appActionResources.all();
       });
       this.post(`/${buildPostAppActionRoute({ itemId: currentItemId })}`, (schema, request) => {

--- a/src/mutations/apps.ts
+++ b/src/mutations/apps.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from 'react-query';
 import { List, Map } from 'immutable';
 import * as Api from '../api';
-import { buildAppActionKey, buildAppDataKey, MUTATION_KEYS } from '../config/keys';
+import { buildAppActionsKey, buildAppDataKey, MUTATION_KEYS } from '../config/keys';
 import { AppAction, AppData, QueryClientConfig } from '../types';
 import { getApiHost, getData, getDataOrThrow } from '../config/utils';
 import {
@@ -119,7 +119,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     },
     onSuccess: (newAppAction: AppAction) => {
       const { itemId } = getData(queryClient);
-      const key = buildAppActionKey(itemId);
+      const key = buildAppActionsKey(itemId);
       const prevData = queryClient.getQueryData<List<AppAction>>(key);
       queryClient.setQueryData(key, prevData?.push(newAppAction));
     },
@@ -128,7 +128,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     },
     onSettled: () => {
       const { itemId } = getData(queryClient);
-      queryClient.invalidateQueries(buildAppActionKey(itemId));
+      queryClient.invalidateQueries(buildAppActionsKey(itemId));
     },
   });
   // this mutation is used for its callback and invalidate the keys


### PR DESCRIPTION
This PR changes the naming of `appAction` to `appActions` anywhere there might be multiple actions. 

This does not affect the exposed API.

closes #28 