### PR TITLE
fix: add creator prop in AppSetting type and mockServer

### DIFF
--- a/src/api/apps.ts
+++ b/src/api/apps.ts
@@ -9,11 +9,11 @@ import {
   buildPostAppActionRoute,
 } from './routes';
 import configureAxios from './axios';
-import { ApiData, AppAction, AppData, LocalContext, UUID } from '../types';
+import { ApiData, AppAction, AppContext, AppData, UUID } from '../types';
 
 const axios = configureAxios();
 
-export const getContext = async (args: ApiData): Promise<LocalContext> => {
+export const getContext = async (args: ApiData): Promise<AppContext> => {
   const { token, itemId, apiHost } = args;
   return axios
     .get(`${apiHost}/${buildGetContextRoute(itemId)}`, {

--- a/src/hooks/appData.ts
+++ b/src/hooks/appData.ts
@@ -1,10 +1,10 @@
-import { List } from 'immutable';
+import { List, RecordOf } from 'immutable';
 import { QueryClient, useQuery } from 'react-query';
 import * as Api from '../api';
 import { MissingFileIdError } from '../config/errors';
 import { buildAppContextKey, buildAppDataKey, buildFileContentKey } from '../config/keys';
 import { getApiHost, getDataOrThrow } from '../config/utils';
-import { AppContextRecord, QueryClientConfig } from '../types';
+import { AppContext, AppContextRecord, QueryClientConfig } from '../types';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   const { retry, cacheTime, staleTime } = queryConfig;
@@ -33,8 +33,12 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       const { token, itemId } = getDataOrThrow(queryClient);
       return useQuery({
         queryKey: buildAppContextKey(itemId),
-        queryFn: () => {
-          return Api.getContext({ itemId, token, apiHost }).then((data) => AppContextRecord(data));
+        queryFn: (): Promise<RecordOf<AppContext>> => {
+          return Api.getContext({
+            itemId,
+            token,
+            apiHost,
+          }).then((data) => AppContextRecord(data));
         },
         ...defaultOptions,
         enabled: Boolean(itemId) && Boolean(token),

--- a/src/hooks/appData.ts
+++ b/src/hooks/appData.ts
@@ -1,10 +1,10 @@
-import { List, Map } from 'immutable';
+import { List } from 'immutable';
 import { QueryClient, useQuery } from 'react-query';
 import * as Api from '../api';
 import { MissingFileIdError } from '../config/errors';
 import { buildAppContextKey, buildAppDataKey, buildFileContentKey } from '../config/keys';
 import { getApiHost, getDataOrThrow } from '../config/utils';
-import { QueryClientConfig } from '../types';
+import { AppContextRecord, QueryClientConfig } from '../types';
 
 export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
   const { retry, cacheTime, staleTime } = queryConfig;
@@ -34,7 +34,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
       return useQuery({
         queryKey: buildAppContextKey(itemId),
         queryFn: () => {
-          return Api.getContext({ itemId, token, apiHost }).then((data) => Map(data));
+          return Api.getContext({ itemId, token, apiHost }).then((data) => AppContextRecord(data));
         },
         ...defaultOptions,
         enabled: Boolean(itemId) && Boolean(token),

--- a/src/mockServer/mockServer.ts
+++ b/src/mockServer/mockServer.ts
@@ -96,6 +96,7 @@ export const mockServer = ({
         updatedAt: new Date().toISOString(),
         name: (idx) => `app-setting-${idx}`,
         itemId: currentItemId,
+        creator: currentMemberId,
       }),
       member: Factory.extend<Member>({
         id: () => v4(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export type AppSetting = {
   id: UUID;
   data: AppSettingData;
   name: string;
+  creator: string;
   createdAt: string;
   updatedAt: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Record } from 'immutable';
+import { List, Record } from 'immutable';
 import { Context, PermissionLevel } from '@graasp/utils';
 
 // generic type
@@ -131,8 +131,8 @@ export const LocalContextRecord = Record<LocalContext>({
 });
 
 export type AppContext = Item & {
-  children: Item[];
-  members: Member[];
+  children: List<Item>;
+  members: List<Member>;
 };
 
 export const AppContextRecord = Record<AppContext>({
@@ -142,8 +142,8 @@ export const AppContextRecord = Record<AppContext>({
   description: '',
   type: '',
   extra: {},
-  children: [],
-  members: [],
+  children: List<Item>(),
+  members: List<Member>(),
 });
 
 export interface ApiData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,22 @@ export const LocalContextRecord = Record<LocalContext>({
   permission: PermissionLevel.Read,
 });
 
+export type AppContext = Item & {
+  children: Item[];
+  members: Member[];
+};
+
+export const AppContextRecord = Record<AppContext>({
+  id: '',
+  name: '',
+  path: '',
+  description: '',
+  type: '',
+  extra: {},
+  children: [],
+  members: [],
+});
+
 export interface ApiData {
   token: Token;
   itemId: UUID;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -77,6 +77,7 @@ export const buildAppSetting = ({
   createdAt: Date.now().toString(),
   updatedAt: Date.now().toString(),
   itemId: 'itemId',
+  creator: v4(),
 });
 
 export const FIXTURE_APP_SETTINGS: AppSetting[] = [


### PR DESCRIPTION
This PR add the `creator` prop to the `AppSetting` type. It also adds it to the mirage factory to be consistent with the real API.

closes #42 