### PR TITLE
feat: add enabled option in app action hook

### DIFF
--- a/src/hooks/appAction.ts
+++ b/src/hooks/appAction.ts
@@ -13,7 +13,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
     staleTime,
   };
   return {
-    useAppActions: () => {
+    useAppActions: ({ enabled = true }: { enabled: boolean }) => {
       const apiHost = getApiHost(queryClient);
       const { token, itemId } = getDataOrThrow(queryClient);
 
@@ -23,7 +23,7 @@ export default (queryClient: QueryClient, queryConfig: QueryClientConfig) => {
           return Api.getAppActions({ itemId, token, apiHost }).then((data) => List(data));
         },
         ...defaultOptions,
-        enabled: Boolean(itemId) && Boolean(token),
+        enabled: Boolean(itemId) && Boolean(token) && enabled,
       });
     },
   };


### PR DESCRIPTION
Allow to disable the query and use `refetch()` to fetch on demand.

closes #57 