### PR TITLE
fix: remove usage of process.env

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "test:ci": "yarn && cd example && yarn && cd .. && yarn test"
   },
   "dependencies": {
-    "@graasp/sdk": "1.2.0",
+    "@graasp/sdk": "1.2.1",
     "axios": "1.4.0",
     "http-status-codes": "2.2.0",
-    "immutable": "4.3.1",
+    "immutable": "4.3.2",
     "miragejs": "0.1.47",
     "qs": "6.11.2",
     "uuid": "9.0.0"

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -37,8 +37,7 @@ const defaultRetryFunction = (failureCount: number, error: unknown) => {
 
 export default (config: Partial<QueryClientConfig>) => {
   const baseConfig = {
-    SHOW_NOTIFICATIONS:
-      config?.SHOW_NOTIFICATIONS || process.env.REACT_APP_SHOW_NOTIFICATIONS === 'true' || false,
+    SHOW_NOTIFICATIONS: config?.SHOW_NOTIFICATIONS || false,
     keepPreviousData: config?.keepPreviousData || false,
     retry: config?.retry ?? defaultRetryFunction,
   };
@@ -55,7 +54,7 @@ export default (config: Partial<QueryClientConfig>) => {
     cacheTime: config?.cacheTime || CACHE_TIME_MILLISECONDS,
     // derive WS_HOST from API_HOST if needed
     // TODO: pass it with the context
-    WS_HOST: config?.WS_HOST || process.env.VITE_WS_HOST || makeWsHostFromAPIHost(config?.API_HOST),
+    WS_HOST: config?.WS_HOST || makeWsHostFromAPIHost(config?.API_HOST),
     // whether websocket support should be enabled
     enableWebsocket: Boolean(config?.enableWebsocket),
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3271,7 +3271,7 @@ __metadata:
   dependencies:
     "@commitlint/cli": 17.6.6
     "@commitlint/config-conventional": 17.6.6
-    "@graasp/sdk": 1.2.0
+    "@graasp/sdk": 1.2.1
     "@tanstack/react-query": 4.32.5
     "@tanstack/react-query-devtools": 4.32.5
     "@testing-library/react-hooks": 8.0.1
@@ -3289,7 +3289,7 @@ __metadata:
     eslint-config-prettier: 9.0.0
     http-status-codes: 2.2.0
     husky: 8.0.3
-    immutable: 4.3.1
+    immutable: 4.3.2
     jest: 29.6.2
     jest-immutable-matchers: 3.0.0
     miragejs: 0.1.47
@@ -3327,22 +3327,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@graasp/sdk@npm:1.2.0"
+"@graasp/sdk@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@graasp/sdk@npm:1.2.1"
   dependencies:
     "@aws-sdk/client-s3": 3.370.0
     "@fastify/secure-session": 6.1.0
     "@graasp/etherpad-api": 2.1.1
     fastify: 4.18.0
     fluent-json-schema: 4.1.0
-    immutable: 4.3.1
+    immutable: 4.3.2
     js-cookie: 3.0.5
     qs: 6.11.2
     typeorm: 0.3.17
     uuid: 9.0.0
-    validator: 13.9.0
-  checksum: 478eeff4f2c505876b6e555c64ab41176c636d971c2012ffbf7196d242ed04807286b34f281f5aa063e5cc82b14eb47a7fb6ba631073906ae78aea31807e53eb
+    validator: 13.11.0
+  checksum: 8507f3157e77a1cf0fb9e01a32c72cbfdb8bd3fd5a960a5fa299dbe36eba4a6f28f5f094a5d09214599e54a1fd91b95e945f80525a6165e4caf96ca9822544b7
   languageName: node
   linkType: hard
 
@@ -11028,10 +11028,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:4.3.1":
-  version: 4.3.1
-  resolution: "immutable@npm:4.3.1"
-  checksum: a3a5ba29bd43f3f9a2e4d599763d7455d11a0ea57e50bf43f2836672fc80003e90d69f2a4f5b589f1f3d6986faf97f08ce1e253583740dd33c00adebab88b217
+"immutable@npm:4.3.2":
+  version: 4.3.2
+  resolution: "immutable@npm:4.3.2"
+  checksum: bb1d0f3eb8ebef04aa9e2c698ba1a248976a4dc0257fa2f1bffaaae575f891395fe9ef39eaf49856d6c4edd31704e300ec563ed44ea9d7c7996186deab91d0ff
   languageName: node
   linkType: hard
 
@@ -18324,7 +18324,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validator@npm:13.9.0, validator@npm:^13.7.0":
+"validator@npm:13.11.0":
+  version: 13.11.0
+  resolution: "validator@npm:13.11.0"
+  checksum: d1e0c27022681420756da25bc03eb08d5f0c66fb008f8ff02ebc95812b77c6be6e03d3bd05cf80ca702e23eeb73dadd66b4b3683173ea2a0bc7cc72820bee131
+  languageName: node
+  linkType: hard
+
+"validator@npm:^13.7.0":
   version: 13.9.0
   resolution: "validator@npm:13.9.0"
   checksum: e2c936f041f61faa42bafd17c6faddf939498666cd82e88d733621c286893730b008959f4cb12ab3e236148a4f3805c30b85e3dcf5e0efd8b0cbcd36c02bfc0c


### PR DESCRIPTION
This PR removes the usage of process.env in the query-client config to allow the use of vite (which does not have `process.env`). 

This is similar to https://github.com/graasp/graasp-query-client/pull/385