### PR TITLE
chore: move the chatbot post mock route from app-code-capsule (graasp/graasp#641)

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3,6 +3,7 @@ export const ITEMS_ROUTE = 'items';
 export const APP_ITEMS_ROUTE = 'app-items';
 export const APP_ACTIONS_ENDPOINT = 'app-action';
 export const APP_SETTINGS_ROUTE = 'app-settings';
+export const CHAT_BOT_ENDPOINT = 'chat-bot';
 
 export const buildGetAppDataRoute = (itemId: string) =>
   `${APP_ITEMS_ROUTE}/${itemId}/${APP_DATA_ENDPOINT}`;
@@ -48,6 +49,9 @@ export const buildPatchAppSettingRoute = (payload: { itemId: string; id: string 
 export const buildDeleteAppSettingRoute = (payload: { itemId: string; id: string }) =>
   `${APP_ITEMS_ROUTE}/${payload.itemId}/${APP_SETTINGS_ROUTE}/${payload.id}`;
 
+  export const buildPostChatBotRoute = (itemId: string) =>
+  `${APP_ITEMS_ROUTE}/${itemId}/${CHAT_BOT_ENDPOINT}`;
+
 export const API_ROUTES = {
   buildDownloadAppDataFileRoute,
   buildDeleteAppDataRoute,
@@ -64,4 +68,5 @@ export const API_ROUTES = {
   buildDeleteAppSettingRoute,
   buildUploadAppSettingFilesRoute,
   buildDownloadAppSettingFileRoute,
+  buildPostChatBotRoute,
 };

--- a/src/mockServer/mockServer.ts
+++ b/src/mockServer/mockServer.ts
@@ -1,6 +1,6 @@
 import { v4 } from 'uuid';
 import { createServer, Model, Factory, RestSerializer, Response, Request } from 'miragejs';
-import { API_ROUTES, buildUploadAppDataFilesRoute } from '../api/routes';
+import { API_ROUTES, buildPostChatBotRoute, buildUploadAppDataFilesRoute } from '../api/routes';
 
 import { buildMockLocalContext, MOCK_SERVER_ITEM, MOCK_SERVER_MEMBER } from './fixtures';
 import { Database, LocalContext } from 'src/types';
@@ -326,6 +326,11 @@ export const mockServer = ({
         //   memberId: currentMemberId,
         // }
         return schema.create('appDataResource');
+      });
+
+      // OpenAI routes
+      this.post(`/${buildPostChatBotRoute(currentItem.id)}`, () => {
+        return { completion: 'Biip boop i am a bot' };
       });
 
       // passthrough external urls


### PR DESCRIPTION
- The mockServer from app-code-capsule is moved to the apps-query-client.
- Basically, in the apps-query-client, there is a new mirage route that handle the chatbot post route, and return a simple statique response. 
- This mock route is used in the app-code-capsule when running test of the chat and allow to remove the cypress intercept in it.
