### PR TITLE
feat: add mobile context communication

### DIFF
--- a/src/components/withContext.tsx
+++ b/src/components/withContext.tsx
@@ -12,6 +12,7 @@ export const defaultContextValue: LocalContext = {
   itemId: '',
   memberId: '',
   settings: {},
+  mobile: false,
   dev: false,
   offline: false,
   lang: 'en',

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export class UndefinedArgument extends Error {
 export type WindowPostMessage = (message: unknown) => void;
 
 export type LocalContext = {
+  mobile?: boolean;
   apiHost: string;
   itemId: UUID;
   memberId: UUID;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -157,6 +157,7 @@ export const buildMockLocalContext = ({
   itemId,
   memberId,
   settings: {},
+  mobile: false,
   context: Context.Builder,
   permission: PermissionLevel.Read,
 });


### PR DESCRIPTION
This PR adds the ability for apps to work on mobile.

Things we had to change:
- The mobile app embeds apps in a WebView but does not provide the same `postMessage` APIs. We can hoverer rely on using the `window.parent.postMessage` as the mobile app will alias `window.parent` to `window.ReactNativeWebView` and the postMessage method behaves the same.
- All future communications are not made using a port but they continue using the `window.parent` as there is no real need to "isolate" from other iframes in the native context.
- add a `mobile` key to the `LocalContext` that is set to `true` when the app is embedded in mobile. This could allow the interface to adapt and display a better UI for larger touch targets. This is also used to choose the communication strategy (as stated above).

TLDR: 
1. added a new `CommunicationChannel` abstraction that allows to use the apps on mobile
2. Apps will need to be updated with this new version of the `query-client` to work on mobile
