### PR TITLE
fix(ws): insert data without duplication

### DIFF
--- a/src/ws/hooks/app.test.ts
+++ b/src/ws/hooks/app.test.ts
@@ -1,4 +1,4 @@
-import { AppAction, AppData } from '@graasp/sdk';
+import { AppAction, AppData, AppSetting } from '@graasp/sdk';
 
 import {
   FIXTURE_APP_ACTIONS,
@@ -86,6 +86,10 @@ describe('Websockets App Hooks', () => {
       };
 
       getHandlerByChannel(handlers, channel)?.handler(appDataEvent);
+      expect(
+        queryClient.getQueryData<AppData[]>(appDataKey)?.filter((a) => a.id === newAppData.id)
+          .length,
+      ).toEqual(1);
       expect(
         queryClient.getQueryData<AppData[]>(appDataKey)?.find((a) => a.id === newAppData.id),
       ).toEqual(newAppData);
@@ -207,7 +211,9 @@ describe('Websockets App Hooks', () => {
       const h = getHandlerByChannel(handlers, channel);
       h?.handler(appDataEvent);
       expect(
-        queryClient.getQueryData<AppData[]>(appSettingsKey)?.find((a) => a.id === newAppSetting.id),
+        queryClient
+          .getQueryData<AppSetting[]>(appSettingsKey)
+          ?.find((a) => a.id === newAppSetting.id),
       ).toEqual(newAppSetting);
     });
 
@@ -226,8 +232,16 @@ describe('Websockets App Hooks', () => {
 
       getHandlerByChannel(handlers, channel)?.handler(appDataEvent);
 
+      // The app setting should be unique.
       expect(
-        queryClient.getQueryData<AppData[]>(appSettingsKey)?.find((a) => a.id === newAppSetting.id),
+        queryClient
+          .getQueryData<AppSetting[]>(appSettingsKey)
+          ?.filter((a) => a.id === newAppSetting.id).length,
+      ).toEqual(1);
+      expect(
+        queryClient
+          .getQueryData<AppSetting[]>(appSettingsKey)
+          ?.find((a) => a.id === newAppSetting.id),
       ).toEqual(newAppSetting);
     });
 
@@ -250,7 +264,9 @@ describe('Websockets App Hooks', () => {
       getHandlerByChannel(handlers, channel)?.handler(appDataEvent);
 
       expect(
-        queryClient.getQueryData<AppData[]>(appSettingsKey)?.find((a) => a.id === newAppSetting.id),
+        queryClient
+          .getQueryData<AppSetting[]>(appSettingsKey)
+          ?.find((a) => a.id === newAppSetting.id),
       ).toBeUndefined();
     });
   });

--- a/src/ws/hooks/app.ts
+++ b/src/ws/hooks/app.ts
@@ -59,11 +59,8 @@ export const configureWsAppDataHooks = (websocketClient?: WebsocketClient) => ({
               if (appDataList) {
                 const appDataPatchedIndex = appDataList.findIndex((a) => a.id === newAppData.id);
                 if (appDataPatchedIndex >= 0) {
-                  queryClient.setQueryData(appDataKey, [
-                    ...appDataList.slice(0, appDataPatchedIndex),
-                    newAppData,
-                    ...appDataList.slice(appDataPatchedIndex, appDataList.length),
-                  ]);
+                  appDataList[appDataPatchedIndex] = newAppData;
+                  queryClient.setQueryData(appDataKey, [...appDataList]);
                 }
               }
               break;
@@ -187,11 +184,8 @@ export const configureWsAppSettingHooks = (websocketClient?: WebsocketClient) =>
                   (a) => a.id === newAppSetting.id,
                 );
                 if (appSettingPatchedIndex >= 0) {
-                  queryClient.setQueryData(appSettingsKey, [
-                    ...appSettingList.slice(0, appSettingPatchedIndex),
-                    newAppSetting,
-                    ...appSettingList.slice(appSettingPatchedIndex, appSettingList.length),
-                  ]);
+                  appSettingList[appSettingPatchedIndex] = newAppSetting;
+                  queryClient.setQueryData(appSettingsKey, [...appSettingList]);
                 }
               }
               break;


### PR DESCRIPTION
when receiving patched data from websockets, the data are replaced and not duplicated

close #263