### PR TITLE
fix: remove credentials for app data blob download

### DIFF
--- a/src/api/appData.ts
+++ b/src/api/appData.ts
@@ -95,9 +95,7 @@ export const getAppDataFile = async ({
   return axios
     .get<Blob>(url, {
       responseType: 'blob',
-      headers: {
-        'Access-Control-Allow-Credentials': true,
-      },
+      withCredentials: false,
     })
     .then(({ data }) => data);
 };


### PR DESCRIPTION
remove credentials when downloading app data file